### PR TITLE
Modify Connection to throw exceptions up to the client

### DIFF
--- a/lib/infusionsoft/connection.rb
+++ b/lib/infusionsoft/connection.rb
@@ -14,19 +14,21 @@ module Infusionsoft
       begin
         result = server.call("#{service_call}", api_key, *args)
         if result.nil?; result = [] end
-      rescue Timeout::Error
-        retry if ok_to_retry
-      rescue
-        retry if ok_to_retry
+      rescue Timeout::Error => timeout
+        # Retry up to 5 times on a Timeout before raising it
+        ok_to_retry(timeout) ? retry : raise
+      rescue => e
+        # Wrap the underlying error in an InfusionAPIError
+        raise InfusionAPIError.new(e.to_s, e)
       end
 
       return result
     end
 
-    def ok_to_retry
+    def ok_to_retry(e)
       @retry_count += 1
       if @retry_count <= 5
-        Rails.logger.info "*** INFUSION API ERROR: retrying #{@retry_count} ***" if Rails
+        Rails.logger.info "*** INFUSION API ERROR: [#{e}] retrying #{@retry_count} ***" if Rails
         true
       else
         false
@@ -36,4 +38,12 @@ module Infusionsoft
   end
 end
 
-class InfusionAPIError < StandardError; end
+# Extend StandardError to keep track of Error being wrapped
+# Pattern from Exceptional Ruby by Avdi Grimm (http://avdi.org/talks/exceptional-ruby-2011-02-04/)
+class InfusionAPIError < StandardError
+  attr_reader :original
+    def initialize(msg, original=nil);
+      super(msg);
+      @original = original;
+    end
+end


### PR DESCRIPTION
Would you be open to changing the error handling behavior to something like this?

I recently was testing code, and I passed in an invalid custom attribute name, e..g:

``` ruby
selected_fields = ['Id', 'FirstName', 'LastName', '_Invalid']
contact = Infusionsoft.contact_find_by_email('user@example.com', selected_fields)
```

contact_find_by_email just returned nil, because Connection was not bubbling up the underlying exception, so I could not programmatically check what went wrong.

This might break backwards compatibility for users that just check for nil for error detection, so this behavior could be enabled by a configuration option as well.  (If you didn't want it as the default behavior.)

Let me know what you think,
Thanks,
Dennis
