### PR TITLE
Switch the argument service_call for invoice_add_manual_payment

### DIFF
--- a/lib/infusionsoft/client/invoice.rb
+++ b/lib/infusionsoft/client/invoice.rb
@@ -102,7 +102,7 @@ module Infusionsoft
       # @param [Boolean] bypass_commissions
       # @return [Boolean]
       def invoice_add_manual_payment(invoice_id, amount, date, type, description, bypass_commissions)
-        response = get('InvoiceService', 'addManualPayment', invoice_id, amount, date, type,
+        response = get('InvoiceService.addManualPayment', invoice_id, amount, date, type,
                        description, bypass_commissions)
       end
 


### PR DESCRIPTION
There was a problem with the service_call argument of invoice_add_manual_payment.

As it was, the call would throw:
"No such handler: InvoiceService"
