### PR TITLE
Fix undefined local variable or method error in InfusionAPIError

### DIFF
--- a/lib/infusionsoft/connection.rb
+++ b/lib/infusionsoft/connection.rb
@@ -45,7 +45,7 @@ end
 class InfusionAPIError < StandardError
   attr_reader :original
     def initialize(msg, original=nil);
-      api_logger.error "ERROR: #{msg}"
+      Infusionsoft.api_logger.error "ERROR: #{msg}"
       super(msg);
       @original = original;
     end


### PR DESCRIPTION
`undefined local variable or method api_logger for #<InfusionAPIError: InfusionAPIError> (NameError)` occurs when a new `InfusionAPIError` is created. `api_logger` is not a method in `InfusionAPIError`.
