### PR TITLE
fix email optin bug

### DIFF
--- a/lib/infusionsoft/client/contact.rb
+++ b/lib/infusionsoft/client/contact.rb
@@ -11,7 +11,7 @@ module Infusionsoft
       #   { :Email => 'test@test.com', :FirstName => 'first_name', :LastName => 'last_name' }
       def contact_add(data)
         contact_id = get('ContactService.add', data)
-        if data.has_key?("Email"); email_optin(data["Email"], "requested information"); end
+        if data.has_key?(:Email); email_optin(data[:Email], "requested information"); end
         return contact_id
       end
       
@@ -31,7 +31,7 @@ module Infusionsoft
       # @return [Integer] id of the contact added or updated
       def contact_add_with_dup_check(data, check_type)
         contact_id = get('ContactService.addWithDupCheck', data, check_type)
-        if data.has_key?("Email"); email_optin(data["Email"], "requested information"); end
+        if data.has_key?(:Email); email_optin(data[:Email], "requested information"); end
         return contact_id
       end
 
@@ -44,7 +44,7 @@ module Infusionsoft
       #   { :FirstName => 'first_name', :StreetAddress1 => '123 N Street' }
       def contact_update(contact_id, data)
         contact_id = get('ContactService.update', contact_id, data)
-        if data.has_key?("Email"); email_optin(data["Email"], "requested information"); end
+        if data.has_key?(:Email); email_optin(data[:Email], "requested information"); end
         return contact_id
       end
 

--- a/test/vcr_cassettes/contact_add.yml
+++ b/test/vcr_cassettes/contact_add.yml
@@ -46,4 +46,48 @@ http_interactions:
       string: <?xml version="1.0" encoding="utf-8"?><methodResponse><params><param><value><i4>3602</i4></value></param></params></methodResponse>
     http_version: 
   recorded_at: Thu, 09 Apr 2015 07:14:00 GMT
+- request:
+    method: post
+    uri: https://test.infusionsoft.com/api/xmlrpc
+    body:
+      encoding: UTF-8
+      string: | 
+        <?xml version="1.0" ?><methodCall><methodName>APIEmailService.optIn</methodName><params><param><value><string>not_a_real_key</string></value></param><param><value><string>testing@test.com</string></value></param><param><value><string>requested information</string></value></param></params></methodCall>
+    headers:
+      User-Agent:
+      - Infusionsoft-1.1.8 (RubyGem)
+      Content-Type:
+      - text/xml; charset=utf-8
+      Content-Length:
+      - '321'
+      Connection:
+      - keep-alive
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Expires:
+      - Fri, 31 Jul 2015 11:55:20 GMT
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '138'
+      Date:
+      - Thu, 30 Jul 2015 23:55:20 GMT
+      Set-Cookie:
+      - app-lb=2466578442.20480.0000; path=/
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="utf-8"?><methodResponse><params><param><value><boolean>1</boolean></value></param></params></methodResponse>
+    http_version: 
+  recorded_at: Thu, 30 Jul 2015 23:55:21 GMT
 recorded_with: VCR 2.9.3

--- a/test/vcr_cassettes/contact_add_dup_check_no_dup.yml
+++ b/test/vcr_cassettes/contact_add_dup_check_no_dup.yml
@@ -46,4 +46,48 @@ http_interactions:
       string: <?xml version="1.0" encoding="utf-8"?><methodResponse><params><param><value><i4>3612</i4></value></param></params></methodResponse>
     http_version: 
   recorded_at: Fri, 10 Apr 2015 08:13:43 GMT
+- request:
+    method: post
+    uri: https://test.infusionsoft.com/api/xmlrpc
+    body:
+      encoding: UTF-8
+      string: | 
+        <?xml version="1.0" ?><methodCall><methodName>APIEmailService.optIn</methodName><params><param><value><string>not_a_real_key</string></value></param><param><value><string>testing@test.com</string></value></param><param><value><string>requested information</string></value></param></params></methodCall>
+    headers:
+      User-Agent:
+      - Infusionsoft-1.1.8 (RubyGem)
+      Content-Type:
+      - text/xml; charset=utf-8
+      Content-Length:
+      - '321'
+      Connection:
+      - keep-alive
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Expires:
+      - Fri, 31 Jul 2015 11:55:20 GMT
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '138'
+      Date:
+      - Thu, 30 Jul 2015 23:55:20 GMT
+      Set-Cookie:
+      - app-lb=2466578442.20480.0000; path=/
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="utf-8"?><methodResponse><params><param><value><boolean>1</boolean></value></param></params></methodResponse>
+    http_version: 
+  recorded_at: Thu, 30 Jul 2015 23:55:21 GMT
 recorded_with: VCR 2.9.3

--- a/test/vcr_cassettes/contact_add_dup_check_with_dup.yml
+++ b/test/vcr_cassettes/contact_add_dup_check_with_dup.yml
@@ -97,6 +97,50 @@ http_interactions:
     uri: https://test.infusionsoft.com/api/xmlrpc
     body:
       encoding: UTF-8
+      string: | 
+        <?xml version="1.0" ?><methodCall><methodName>APIEmailService.optIn</methodName><params><param><value><string>not_a_real_key</string></value></param><param><value><string>testing@test.com</string></value></param><param><value><string>requested information</string></value></param></params></methodCall>
+    headers:
+      User-Agent:
+      - Infusionsoft-1.1.8 (RubyGem)
+      Content-Type:
+      - text/xml; charset=utf-8
+      Content-Length:
+      - '321'
+      Connection:
+      - keep-alive
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Expires:
+      - Fri, 31 Jul 2015 11:55:20 GMT
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '138'
+      Date:
+      - Thu, 30 Jul 2015 23:55:20 GMT
+      Set-Cookie:
+      - app-lb=2466578442.20480.0000; path=/
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="utf-8"?><methodResponse><params><param><value><boolean>1</boolean></value></param></params></methodResponse>
+    http_version: 
+  recorded_at: Thu, 30 Jul 2015 23:55:21 GMT  
+- request:
+    method: post
+    uri: https://test.infusionsoft.com/api/xmlrpc
+    body:
+      encoding: UTF-8
       string: |
         <?xml version="1.0" ?><methodCall><methodName>ContactService.load</methodName><params><param><value><string>not_a_real_key</string></value></param><param><value><i4>3606</i4></value></param><param><value><array><data><value><string>Company</string></value></data></array></value></param></params></methodCall>
     headers:


### PR DESCRIPTION
I noticed in Infusionsoft that emails were not being opted in, on further investigation it appeared the 'email_optin' method was never getting triggered.

This was because data.has_key?("Email") is looking for a string as the key.

However we're supplying the data in a hash as instructed with a symbol as the key:

    { :Email => 'test@test.com', :FirstName => 'first_name', :LastName => 'last_name' }

The tests still pass because the email_optin method never gets executed. 

When email_optin does get executed, the tests fail because there's no VCR's for the APIEmailService.optIn call.