### PR TITLE
Add error logging to failed requests

### DIFF
--- a/lib/infusionsoft/request.rb
+++ b/lib/infusionsoft/request.rb
@@ -50,7 +50,7 @@ module Infusionsoft
       opts.merge!( { payload: payload.to_json }) unless payload.empty?
       resp = RestClient::Request.execute(opts)
     rescue RestClient::ExceptionWithResponse => err
-      api_logger.error "Infusionsoft API Error: #{err}"
+      api_logger.error "[ERROR]: #{err}"
     else
       return JSON.parse(resp.body) if resp.body # Some calls respond w nothing
     end

--- a/lib/infusionsoft/request.rb
+++ b/lib/infusionsoft/request.rb
@@ -50,7 +50,7 @@ module Infusionsoft
       opts.merge!( { payload: payload.to_json }) unless payload.empty?
       resp = RestClient::Request.execute(opts)
     rescue RestClient::ExceptionWithResponse => err
-      # log error?
+      api_logger.error "Infusionsoft API Error: #{err}"
     else
       return JSON.parse(resp.body) if resp.body # Some calls respond w nothing
     end


### PR DESCRIPTION
This adds a basic error log for failed requests to the Infusionsoft API.

See issue #77 
