### PR TITLE
Add keap api key to call headers

### DIFF
--- a/lib/infusionsoft/connection.rb
+++ b/lib/infusionsoft/connection.rb
@@ -14,7 +14,7 @@ module Infusionsoft
         'port' => 443,
         'use_ssl' => true
       })
-      client.http_header_extra = {'User-Agent' => user_agent}
+      client.http_header_extra = {'User-Agent' => user_agent, 'X-Keap-API-Key' => api_key}
       begin
         api_logger.info "CALL: #{service_call} api_url: #{api_url} at:#{Time.now} args:#{args.inspect}"
         result = client.call("#{service_call}", api_key, *args)


### PR DESCRIPTION
Hello. 
Starting Oct. 31, 2024, Keap is sunsetting the use of API legacy keys for all users.
This is [instruction](https://help.keap.com/help/sunsetting-legacy-api-keys) how to prepare to changes.
If we use config 'use_oauth', we will need to add only X-Keap-API-Key header