### PR TITLE
adding api token for new Personal Access Tokens & Service Account Keys

### DIFF
--- a/lib/infusionsoft.rb
+++ b/lib/infusionsoft.rb
@@ -1,4 +1,3 @@
-
 require 'infusionsoft/api'
 require 'infusionsoft/client'
 require 'infusionsoft/configuration'

--- a/lib/infusionsoft.rb
+++ b/lib/infusionsoft.rb
@@ -1,3 +1,6 @@
+
+puts "Loading Infusionsoft from: #{__FILE__}"
+
 require 'infusionsoft/api'
 require 'infusionsoft/client'
 require 'infusionsoft/configuration'

--- a/lib/infusionsoft.rb
+++ b/lib/infusionsoft.rb
@@ -1,6 +1,4 @@
 
-puts "Loading Infusionsoft from: #{__FILE__}"
-
 require 'infusionsoft/api'
 require 'infusionsoft/client'
 require 'infusionsoft/configuration'

--- a/lib/infusionsoft/configuration.rb
+++ b/lib/infusionsoft/configuration.rb
@@ -7,6 +7,7 @@ module Infusionsoft
     VALID_OPTION_KEYS = [
       :api_url,
       :api_key,
+      :api_token,
       :api_logger,
       :use_oauth,
       :user_agent # allows you to change the User-Agent of the request headers
@@ -47,6 +48,10 @@ module Infusionsoft
 
     def api_logger
       @api_logger || Infusionsoft::APILogger.new
+    end
+
+    def api_key
+      @api_key || 'na'
     end
   end
 

--- a/lib/infusionsoft/connection.rb
+++ b/lib/infusionsoft/connection.rb
@@ -5,8 +5,22 @@ module Infusionsoft
   module Connection
     private
 
+    
     def connection(service_call, *args)
-      path = use_oauth ? "/crm/xmlrpc/v1?access_token=#{api_key}" : "/api/xmlrpc"
+
+      headers = {'User-Agent' => user_agent}
+
+      if api_token
+        api_url = 'api.infusionsoft.com'
+        path = "/crm/xmlrpc/v1"
+        headers["X-Keap-API-Key"] = api_token
+      elsif use_oauth
+        path = "/crm/xmlrpc/v1?access_token=#{api_key}"
+      else
+        path = "/api/xmlrpc"
+      end
+
+      #path = use_oauth ? "/crm/xmlrpc/v1?access_token=#{api_key}" : "/api/xmlrpc"
       
       client = XMLRPC::Client.new3({
         'host' => api_url,
@@ -14,7 +28,7 @@ module Infusionsoft
         'port' => 443,
         'use_ssl' => true
       })
-      client.http_header_extra = {'User-Agent' => user_agent}
+      client.http_header_extra = headers
       begin
         api_logger.info "CALL: #{service_call} api_url: #{api_url} at:#{Time.now} args:#{args.inspect}"
         result = client.call("#{service_call}", api_key, *args)

--- a/lib/infusionsoft/connection.rb
+++ b/lib/infusionsoft/connection.rb
@@ -19,8 +19,6 @@ module Infusionsoft
       else
         path = "/api/xmlrpc"
       end
-
-      #path = use_oauth ? "/crm/xmlrpc/v1?access_token=#{api_key}" : "/api/xmlrpc"
       
       client = XMLRPC::Client.new3({
         'host' => api_url,
@@ -28,7 +26,9 @@ module Infusionsoft
         'port' => 443,
         'use_ssl' => true
       })
+      
       client.http_header_extra = headers
+      
       begin
         api_logger.info "CALL: #{service_call} api_url: #{api_url} at:#{Time.now} args:#{args.inspect}"
         result = client.call("#{service_call}", api_key, *args)


### PR DESCRIPTION
This creates a new configuration key, "api_token," for use with the latest required personal access tokens or service account keys. When using the api_token configuration, the old api_key is ignored by the service call. When the connection is executed, and an api_token is present, the api_url is corrected, and the api_token is added as a header to the request as required for authorization. If no api_key is present in the configuration, a dummy key is added and still included in the request. This is because the XML-RPC API still expects an api_key at the new URL, but the api_key is ignored for authentication purposes.

For those still using this gem for Infusionsoft's XML-RPC API, this should work without breaking for anyone who hasn't updated yet. All tests passed after these changes.