### PR TITLE
Deprecated legacy key migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,23 @@ A Ruby wrapper for the Infusionsoft API
 2. Enable the API on your Infusionsoft account (if you haven't already) and generate your API Key: [See Infusionsoft Doc](https://classic-infusionsoft.knowledgeowl.com/help/api-key)
 3. Then create an initializer in `config\initializers` called infusionsoft.rb and the following
 
+## Service Account Key (SAK)
+
 ```ruby
 # Added to your config\initializers file
 Infusionsoft.configure do |config|
-  config.api_url = 'YOUR_INFUSIONSOFT_URL' # example infused.infusionsoft.com DO NOT INCLUDE https://
+  config.api_url = 'api.infusionsoft.com' # do not include https://
+  config.sak_key = 'YOUR_INFUSIONSOFT_SAK_KEY' # See: https://developer.infusionsoft.com/pat-and-sak/
+  config.api_logger = Logger.new("#{Rails.root}/log/infusionsoft_api.log") # optional logger file
+end
+```
+
+## Legacy Key (will be deprecated)
+
+```ruby
+# Added to your config\initializers file
+Infusionsoft.configure do |config|
+  config.api_url = 'api.infusionsoft.com' # do not include https://
   config.api_key = 'YOUR_INFUSIONSOFT_API_KEY'
   config.api_logger = Logger.new("#{Rails.root}/log/infusionsoft_api.log") # optional logger file
 end

--- a/lib/infusionsoft/configuration.rb
+++ b/lib/infusionsoft/configuration.rb
@@ -7,6 +7,7 @@ module Infusionsoft
     VALID_OPTION_KEYS = [
       :api_url,
       :api_key,
+      :sak_key,
       :api_logger,
       :use_oauth,
       :user_agent # allows you to change the User-Agent of the request headers

--- a/lib/infusionsoft/connection.rb
+++ b/lib/infusionsoft/connection.rb
@@ -6,18 +6,18 @@ module Infusionsoft
     private
 
     def connection(service_call, *args)
-      path = use_oauth ? "/crm/xmlrpc/v1?access_token=#{api_key}" : "/api/xmlrpc"
-      
+      path = use_oauth ? "/crm/xmlrpc/v1?access_token=#{api_key}" : "/crm/xmlrpc/v1"
+
       client = XMLRPC::Client.new3({
         'host' => api_url,
         'path' => path,
         'port' => 443,
         'use_ssl' => true
       })
-      client.http_header_extra = {'User-Agent' => user_agent}
+      client.http_header_extra = {'User-Agent' => user_agent, 'Authorization' => "Bearer #{api_key}"}
       begin
         api_logger.info "CALL: #{service_call} api_url: #{api_url} at:#{Time.now} args:#{args.inspect}"
-        result = client.call("#{service_call}", api_key, *args)
+        result = client.call("#{service_call}", *args)
         if result.nil?; ok_to_retry('nil response') end
       rescue Timeout::Error => timeout
         # Retry up to 5 times on a Timeout before raising it

--- a/lib/infusionsoft/connection.rb
+++ b/lib/infusionsoft/connection.rb
@@ -6,16 +6,17 @@ module Infusionsoft
     private
 
     def connection(service_call, *args)
-      path = use_oauth ? "/crm/xmlrpc/v1?access_token=#{api_key}" : "/crm/xmlrpc/v1"
-
       client = XMLRPC::Client.new3({
         'host' => api_url,
-        'path' => path,
+        'path' => '/crm/xmlrpc/v1',
         'port' => 443,
         'use_ssl' => true
       })
-      client.http_header_extra = {'User-Agent' => user_agent, 'Authorization' => "Bearer #{api_key}"}
+      client.http_header_extra = define_headers
+
       begin
+        # Fill the api_key param and doesn't send real api_key if is present - Avoid error https://github.com/nateleavitt/infusionsoft/pull/85#issuecomment-2404189445
+        args.insert(0, '')
         api_logger.info "CALL: #{service_call} api_url: #{api_url} at:#{Time.now} args:#{args.inspect}"
         result = client.call("#{service_call}", *args)
         if result.nil?; ok_to_retry('nil response') end
@@ -44,5 +45,18 @@ module Infusionsoft
       end
     end
 
+    def define_headers
+      headers = { 'User-Agent' => user_agent }
+    
+      if use_oauth
+        headers['Authorization'] = "Bearer #{api_key}"
+      elsif sak_key
+        headers['Authorization'] = "Bearer #{sak_key}"
+      else
+        headers['X-Keap-API-Key'] = api_key
+      end
+
+      headers
+    end
   end
 end


### PR DESCRIPTION
These changes seek to maintain the usability of the gem according to the Legacy Api Key deprecation plan.

Ref:
[Legacy Key Deprecation](https://developer.infusionsoft.com/legacy-key-deprecation/)
[Schedule for Legacy Key Deprecation](https://docs.google.com/document/d/1TyiF0U3TO09hz-d0R26E9wb9EIBS1wpGrCyl2WjSxCU/preview?tab=t.0)
[Legacy Key Migration](https://developer.infusionsoft.com/legacy-key-migration/)
[Personal Access Tokens & Service Account Keys](https://developer.infusionsoft.com/pat-and-sak/)